### PR TITLE
Listen on IPv4 and IPv6 adapters

### DIFF
--- a/test/server/index.js
+++ b/test/server/index.js
@@ -266,4 +266,4 @@ app.use(async (err, req, res, next) => {
 });
 
 let server = http.createServer(app);
-server.listen(process.env.NODE_PORT === undefined ? 8080 : process.env.NODE_PORT, "0.0.0.0");
+server.listen(process.env.NODE_PORT === undefined ? 8080 : process.env.NODE_PORT, "::");


### PR DESCRIPTION
Listening on `0.0.0.0` explicitly binds to IPv4. However, listening on `::` binds to both IPv4 and IPv6. On my network, `localhost.org` resolved to `::1` by default.

Note: I don't have an IPv4-only network on which to test this change. I cannot verify that it doesn't break IPv4-only usage scenarios.