### PR TITLE
test: fix test server w/ old node sdks

### DIFF
--- a/test/server/index.js
+++ b/test/server/index.js
@@ -265,8 +265,13 @@ app.post(
     "/update-jwt-with-handle",
     (req, res, next) => verifySession()(req, res, next),
     async (req, res) => {
-        await Session.updateAccessTokenPayload(req.session.getHandle(), req.body);
-        res.json(req.session.getAccessTokenPayload());
+        if (Session.getJWTPayload === !undefined) {
+            await Session.updateJWTPayload(req.session.getHandle(), req.body);
+            res.json(req.session.getJWTPayload());
+        } else {
+            await Session.updateAccessTokenPayload(req.session.getHandle(), req.body);
+            res.json(req.session.getAccessTokenPayload());
+        }
     }
 );
 


### PR DESCRIPTION
## Summary of change
Fix test server with old node sdks that had a different interface for updating/getting access token payloads

## Related issues
- #121

## Test Plan
test only change

## Documentation changes
test only change

## Checklist for important updates
- [ ] Changelog has been updated
- [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `lib/ts/version.ts`
- [ ] Changes to the version if needed
   - In `package.json`
   - In `package-lock.json`
   - In `lib/ts/version.ts`
- [x] Had run `npm run build-pretty`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
