### PR TITLE
test: empty header test fix

### DIFF
--- a/test/interception.basic1.test.js
+++ b/test/interception.basic1.test.js
@@ -3262,6 +3262,7 @@ addTestCases((name, transferMethod, setupFunc, setupArgs = []) => {
             });
             await page.evaluate(async () => {
                 const userId = "testing-supertokens-website";
+                assert.strictEqual(document.cookie, "");
                 const loginResponse = await toTest({
                     url: `${BASE_URL}/login`,
                     method: "post",
@@ -3275,12 +3276,12 @@ addTestCases((name, transferMethod, setupFunc, setupArgs = []) => {
                 assert.strictEqual(loginResponse.statusCode, 200);
                 assert.strictEqual(loginResponse.responseText, userId);
 
-                assert.strictEqual(await supertokens.doesSessionExist(), true);
+                assert.notStrictEqual(document.cookie, "");
             });
             await page.setRequestInterception(false);
         });
 
-        it("should log out work fine if the last header is an empty access-token", async () => {
+        it("should log out fine if the last header is an empty access-token", async () => {
             await startST();
             await setup();
             await page.setRequestInterception(true);


### PR DESCRIPTION
## Summary of change

The test was originally working, but broke after the jwt in the test constant expired

## Related issues
- https://app.circleci.com/pipelines/github/supertokens/supertokens-website/1459/workflows/d60e7908-5453-4fc7-9ebb-74288e850d29/jobs/711

## Test Plan
N/A

## Documentation changes
N/A

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `lib/ts/version.ts`
- [ ] Changes to the version if needed
   - In `package.json`
   - In `package-lock.json`
   - In `lib/ts/version.ts`
- [ ] Had run `npm run build-pretty`
- [ ] Had installed and ran the pre-commit hook
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
