### PR TITLE
test: make mocha always exit when all tests ran in CI

### DIFF
--- a/.circleci/setupAndTestWithFreeCore.sh
+++ b/.circleci/setupAndTestWithFreeCore.sh
@@ -56,7 +56,7 @@ pid=$!
 cd ../../
 
 if ! [[ -z "${CIRCLE_NODE_TOTAL}" ]]; then
-    TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=/dev/null" npx mocha --reporter mocha-multi --no-config --require isomorphic-fetch --timeout 500000 $(npx mocha-split-tests -r ./runtime.log -t $CIRCLE_NODE_TOTAL -g $CIRCLE_NODE_INDEX -f 'test/*.test.js')
+    TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag INSTALL_PATH=../supertokens-root multi="spec=- mocha-junit-reporter=/dev/null" npx mocha --exit --reporter mocha-multi --no-config --require isomorphic-fetch --timeout 500000 $(npx mocha-split-tests -r ./runtime.log -t $CIRCLE_NODE_TOTAL -g $CIRCLE_NODE_INDEX -f 'test/*.test.js')
 else
     TEST_MODE=testing SUPERTOKENS_CORE_TAG=$coreTag INSTALL_PATH=../supertokens-root npm test
 fi


### PR DESCRIPTION
## Summary of change
test: make mocha always exit when all tests ran in CI

## Related issues
- [Failed CI run](https://app.circleci.com/pipelines/github/supertokens/supertokens-website/1653/workflows/85e57bfc-0e8b-49da-8620-05227a3074dd/jobs/850)

## Test Plan
N/A

## Documentation changes
N/A

## Checklist for important updates
- [x] Changelog has been updated
- [x] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `lib/ts/version.ts`
- [x] Changes to the version if needed
   - In `package.json`
   - In `package-lock.json`
   - In `lib/ts/version.ts`
- [x] Had run `npm run build-pretty`
- [x] Had installed and ran the pre-commit hook
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
