### PR TITLE
fix: tests

### DIFF
--- a/test/cross.auto_refresh.test.js
+++ b/test/cross.auto_refresh.test.js
@@ -896,12 +896,12 @@ addTestCases((name, transferMethod, setupFunc, setupArgs = []) => {
 
             assert(
                 consoleLogs.includes(
-                    "Saving to cookies was not successful, this indicates a configuration error or the browser preventing us from writing the cookies (e.g.: incognito mode)."
+                    "Saving to cookies was not successful, this indicates a configuration error or the browser preventing us from writing the cookies."
                 )
             );
             assert(
                 consoleLogs.includes(
-                    "Failed to retrieve local session state from cookies after a successful session refresh. This indicates a configuration error or that the browser is preventing cookie writes (e.g., incognito mode)."
+                    "Failed to retrieve local session state from cookies after a successful session refresh. This indicates a configuration error or that the browser is preventing cookie writes."
                 )
             );
         });

--- a/test/interception.basic1.test.js
+++ b/test/interception.basic1.test.js
@@ -280,13 +280,18 @@ addTestCases((name, transferMethod, setupFunc, setupArgs = []) => {
             assert(
                 logs.some(str =>
                     str.includes(
-                        "Saving to cookies was not successful, this indicates a configuration error or the browser preventing us from writing the cookies (e.g.: incognito mode)."
+                        "Saving to cookies was not successful, this indicates a configuration error or the browser preventing us from writing the cookies."
                     )
                 )
             );
 
             const cookies = await page.cookies();
-            assert.strictEqual(cookies.length, 0);
+            // Assert that none of the frontend cookies are set
+            const frontendCookies =
+                transferMethod === "cookie"
+                    ? ["sAntiCsrf", "sFrontToken", "st-last-access-token-update"]
+                    : ["sFrontToken", "st-last-access-token-update", "st-access-token", "st-refresh-token"];
+            assert(frontendCookies.every(cookieName => !cookies.find(cookie => cookie.name === cookieName)));
         });
 
         it("test rid is there", async function () {


### PR DESCRIPTION
## Summary of change

This PR fixes two tests - 

1. should break out of session refresh loop if cookie writes are disabled
     We removed (incognito mode) from the error message but the test wasn't updated.
     
2. test warnings when cookie writes are not successful
     The error message needed to updated here as well. Along with that we needed to update the cookies check to only the frontend cookies as the backend cookies can be present even if frontend is unable to write to cookies. This test was passing previously because an additional refresh call was clearing the backend cookies as well as explained in #263 




## Related issues
- Link to issue1 here
- Link to issue1 here

## Test Plan
(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] `frontendDriverInterfaceSupported.json` file has been updated (if needed)
   - Along with the associated array in `lib/ts/version.ts`
- [ ] Changes to the version if needed
   - In `package.json`
   - In `package-lock.json`
   - In `lib/ts/version.ts`
- [ ] Had run `npm run build-pretty`
- [ ] Had installed and ran the pre-commit hook
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
